### PR TITLE
Add platform for mac usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
   # MySQL server
   mysql:
     container_name: svip-mysql
+    platform: linux/amd64
     image: mysql:5
     restart: unless-stopped
     environment:


### PR DESCRIPTION
When launching through docker, the SQL database fails to build on mac. This fixes it for mac, but I am unsure if this will cause errors on windows. 