### PR TITLE
dev hashalgofixes

### DIFF
--- a/core/src/main/java/org/svip/sbomanalysis/qualityattributes/pipelines/SVIPPipeline.java
+++ b/core/src/main/java/org/svip/sbomanalysis/qualityattributes/pipelines/SVIPPipeline.java
@@ -140,9 +140,10 @@ public class SVIPPipeline implements CDX14Tests, SPDX23Tests {
                 if(hashes != null){
                     for(String hashAlgo : hashes.keySet()){
                         String hashValue = hashes.get(hashAlgo);
+                        Hash hash = new Hash(hashAlgo, hashValue);
                         componentResults.addAll(hashTest.test(hashAlgo, hashValue));
                         componentResults.add(supportedHash("Supported CDX Hash",
-                                hashAlgo, component.getName()));
+                                hash, component.getName()));
                     }
                 }
 
@@ -221,24 +222,25 @@ public class SVIPPipeline implements CDX14Tests, SPDX23Tests {
      * Check if a hash algorithm in the given SVIP SBOM is supported
      * within CycloneDX
      * @param field the field that's tested
-     * @param value the bom ref tested
+     * @param hash the hash to be tested
      * @param componentName the component's name to product the result
      * @return the result of if the hash algorithm is supported
      */
     @Override
-    public Result supportedHash(String field, String value, String componentName) {
+    public Result supportedHash(String field, Hash hash, String componentName) {
         String testName = "SupportedCDXHash";
         ResultFactory resultFactory = new ResultFactory(testName,
                 ATTRIBUTE.CDX14, ATTRIBUTE.UNIQUENESS);
 
+        String algorithm = hash.getAlgorithm().toString();
         // hash is unsupported, test fails
-        if(Hash.isSPDXExclusive(Hash.Algorithm.valueOf(value))){
-            return resultFactory.fail(field, INFO.INVALID, value,
+        if(Hash.isSPDXExclusive(hash.getAlgorithm())){
+            return resultFactory.fail(field, INFO.INVALID, algorithm,
                     componentName);
         }
         // hash is supported, test passes
         else{
-            return resultFactory.pass(field, INFO.VALID, value,
+            return resultFactory.pass(field, INFO.VALID, algorithm,
                     componentName);
         }
     }

--- a/core/src/main/java/org/svip/sbomanalysis/qualityattributes/pipelines/interfaces/schemas/CycloneDX14/CDX14Tests.java
+++ b/core/src/main/java/org/svip/sbomanalysis/qualityattributes/pipelines/interfaces/schemas/CycloneDX14/CDX14Tests.java
@@ -2,6 +2,7 @@ package org.svip.sbomanalysis.qualityattributes.pipelines.interfaces.schemas.Cyc
 
 import org.svip.sbomanalysis.qualityattributes.pipelines.interfaces.generics.QAPipeline;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.Result;
+import org.svip.sbom.model.uids.Hash;
 
 /**
  * file: CDX14Tests.java
@@ -35,11 +36,11 @@ public interface CDX14Tests extends QAPipeline {
      * Check if a hash algorithm in the given CycloneDX 1.4 SBOM is supported
      * within CycloneDX
      * @param field the field that's tested
-     * @param value the bom ref tested
+     * @param hash the hash to be tested
      * @param componentName the component's name to product the result
      * @return the result of if the hash algorithm is supported
      */
-    Result supportedHash(String field, String value, String componentName);
+    Result supportedHash(String field, Hash hash, String componentName);
 
 
 }

--- a/core/src/main/java/org/svip/sbomanalysis/qualityattributes/pipelines/schemas/CycloneDX14/CDX14Pipeline.java
+++ b/core/src/main/java/org/svip/sbomanalysis/qualityattributes/pipelines/schemas/CycloneDX14/CDX14Pipeline.java
@@ -114,9 +114,10 @@ public class CDX14Pipeline implements CDX14Tests {
                 if(hashes != null){
                     for(String hashAlgo : hashes.keySet()){
                         String hashValue = hashes.get(hashAlgo);
+                        Hash hash = new Hash(hashAlgo, hashValue);
                         componentResults.addAll(hashTest.test(hashAlgo, hashValue));
                         componentResults.add(supportedHash("Supported CDX Hash",
-                                hashAlgo, component.getName()));
+                                hash, component.getName()));
                     }
                 }
 
@@ -195,24 +196,25 @@ public class CDX14Pipeline implements CDX14Tests {
      * Check if a hash algorithm in the given CycloneDX 1.4 SBOM is supported
      * within CycloneDX
      * @param field the field that's tested
-     * @param value the hash algorithm tested
+     * @param hash the hash to be tested
      * @param componentName the component's name to product the result
      * @return the result of if the hash algorithm is supported
      */
     @Override
-    public Result supportedHash(String field, String value, String componentName) {
+    public Result supportedHash(String field, Hash hash, String componentName) {
         String testName = "SupportedCDXHash";
         ResultFactory resultFactory = new ResultFactory(testName,
                 ATTRIBUTE.CDX14, ATTRIBUTE.UNIQUENESS);
 
+        String algorithm = hash.getAlgorithm().toString();
         // hash is unsupported, test fails
-        if(Hash.isSPDXExclusive(Hash.Algorithm.valueOf(value))){
-            return resultFactory.fail(field, INFO.INVALID, value,
+        if(Hash.isSPDXExclusive(hash.getAlgorithm())){
+            return resultFactory.fail(field, INFO.INVALID, algorithm,
                     componentName);
         }
         // hash is supported, test passes
         else{
-            return resultFactory.pass(field, INFO.VALID, value,
+            return resultFactory.pass(field, INFO.VALID, algorithm,
                     componentName);
         }
     }

--- a/core/src/test/java/org/svip/sbomanalysis/qualityattributes/pipelines/SVIPPipelineTest.java
+++ b/core/src/test/java/org/svip/sbomanalysis/qualityattributes/pipelines/SVIPPipelineTest.java
@@ -3,6 +3,7 @@ package org.svip.sbomanalysis.qualityattributes.pipelines;
 import org.junit.jupiter.api.Test;
 import org.svip.sbom.model.shared.metadata.CreationData;
 import org.svip.sbom.model.shared.metadata.Organization;
+import org.svip.sbom.model.uids.Hash;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.Result;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.enumerations.STATUS;
 
@@ -101,13 +102,15 @@ class SVIPPipelineTest {
 
     @Test
     void supportedHash_unsupported_fail_test() {
-        Result r = svipPipeline.supportedHash("Hash Algorithm", testSPDXExclusiveHash, "Component");
+        Hash hash = new Hash(testSPDXExclusiveHash, "asdfasdfasdfasdfa");
+        Result r = svipPipeline.supportedHash("Hash Algorithm", hash, "Component");
         assertEquals(STATUS.FAIL, r.getStatus());
     }
 
     @Test
     void supportedHash_supported_pass_test() {
-        Result r = svipPipeline.supportedHash("Hash Algorithm", testSupportedHash, "Component");
+        Hash hash = new Hash(testSupportedHash, "asdfasdfasdfasdfa");
+        Result r = svipPipeline.supportedHash("Hash Algorithm", hash, "Component");
         assertEquals(STATUS.PASS, r.getStatus());
     }
 

--- a/core/src/test/java/org/svip/sbomanalysis/qualityattributes/pipelines/schemas/CycloneDX14/CDX14PipelineTest.java
+++ b/core/src/test/java/org/svip/sbomanalysis/qualityattributes/pipelines/schemas/CycloneDX14/CDX14PipelineTest.java
@@ -1,6 +1,7 @@
 package org.svip.sbomanalysis.qualityattributes.pipelines.schemas.CycloneDX14;
 
 import org.junit.jupiter.api.Test;
+import org.svip.sbom.model.uids.Hash;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.Result;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.enumerations.STATUS;
 
@@ -80,13 +81,15 @@ class CDX14PipelineTest {
 
     @Test
     void supportedHash_unsupported_fail_test() {
-        Result r = cdx14Pipeline.supportedHash("Hash Algorithm", testSPDXExclusiveHash, "Component");
+        Hash hash = new Hash(testSPDXExclusiveHash, "asdfasdfasdfasdfa");
+        Result r = cdx14Pipeline.supportedHash("Hash Algorithm", hash, "Component");
         assertEquals(STATUS.FAIL, r.getStatus());
     }
 
     @Test
     void supportedHash_supported_pass_test() {
-        Result r = cdx14Pipeline.supportedHash("Hash Algorithm", testSupportedHash, "Component");
+        Hash hash = new Hash(testSupportedHash, "asdfasdfasdfasdfa");
+        Result r = cdx14Pipeline.supportedHash("Hash Algorithm", hash, "Component");
         assertEquals(STATUS.PASS, r.getStatus());
     }
 }

--- a/core/src/test/java/org/svip/sbomanalysis/qualityattributes/tests/HashTestTests.java
+++ b/core/src/test/java/org/svip/sbomanalysis/qualityattributes/tests/HashTestTests.java
@@ -2,6 +2,7 @@ package org.svip.sbomanalysis.qualityattributes.tests;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.svip.sbom.model.uids.Hash;
 import org.svip.sbomanalysis.qualityattributes.pipelines.schemas.CycloneDX14.CDX14Pipeline;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.Result;
 import org.svip.sbomanalysis.qualityattributes.resultfactory.enumerations.STATUS;
@@ -77,16 +78,18 @@ class HashTestTests {
     }
 
     @Test
-    public void supportedCDXHash_fail_test(){
+    void supportedCDXHash_unsupported_fail_test() {
         CDX14Pipeline cdx14Pipeline = new CDX14Pipeline();
-        Result r = cdx14Pipeline.supportedHash("Supported Hash", testSPDXExclusiveHash, "Component");
+        Hash hash = new Hash(testSPDXExclusiveHash, "asdfasdfasdfasdfa");
+        Result r = cdx14Pipeline.supportedHash("Hash Algorithm", hash, "Component");
         assertEquals(STATUS.FAIL, r.getStatus());
     }
 
     @Test
-    public void supportedCDXHash_pass_test(){
+    void supportedCDXHash_supported_pass_test() {
         CDX14Pipeline cdx14Pipeline = new CDX14Pipeline();
-        Result r = cdx14Pipeline.supportedHash("Supported Hash", testHashAlgo1, "Component");
+        Hash hash = new Hash(testHashAlgo1, "asdfasdfasdfasdfa");
+        Result r = cdx14Pipeline.supportedHash("Hash Algorithm", hash, "Component");
         assertEquals(STATUS.PASS, r.getStatus());
     }
 


### PR DESCRIPTION
PR to fix issues with supportedHash tests in CDX14 and SVIP pipelines.

Before running `supportedHash` test, create a new Hash object with the given values to prevent use of raw string in test