### PR TITLE
CI/CD Build and Test Only on Open PR Hotfix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3.5.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,17 @@ on:
       paths-ignore:
         - '**/resources/**'
   pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
     branches:  
       - 'dev'   # todo: replace with vars
       - 'main'  # todo: replace with vars
     paths-ignore:
       - '**/resources/**'
 jobs:
+  # only run on open pull request
   build-test:
-    runs-on: windows-latest
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3.5.2


### PR DESCRIPTION
Tests now take several minutes to complete. To prevent excessive testing and a less overwhelmed CI/CD, tests are run only on OPEN pull requests, not drafts