### PR TITLE
Audit Round 2 Fixes

### DIFF
--- a/core/src/main/java/org/svip/serializers/deserializer/CDX14JSONDeserializer.java
+++ b/core/src/main/java/org/svip/serializers/deserializer/CDX14JSONDeserializer.java
@@ -94,18 +94,21 @@ public class CDX14JSONDeserializer extends StdDeserializer<CDX14SBOM> implements
         // SPEC VERSION
         if (node.get("specVersion") != null) sbomBuilder.setSpecVersion(node.get("specVersion").asText());
 
-        // LICENSES
-        JsonNode licenses = node.get("metadata").get("licenses");
-        if (licenses != null)
-            for (JsonNode license : licenses)
-                sbomBuilder.addLicense(license.asText());
+        if(node.get("metadata") != null){
 
-        // METADATA
-        sbomBuilder.setCreationData(resolveMetadata(node.get("metadata"), sbomBuilder));
+            // LICENSES
+            JsonNode licenses = node.get("metadata").get("licenses");
+            if (licenses != null)
+                for (JsonNode license : licenses)
+                    sbomBuilder.addLicense(license.asText());
 
-        // ROOT COMPONENT
-        if (node.get("metadata").get("component") != null)
-            sbomBuilder.setRootComponent(resolveComponent(componentBuilder, node.get("metadata").get("component")));
+            // METADATA
+            sbomBuilder.setCreationData(resolveMetadata(node.get("metadata"), sbomBuilder));
+
+            // ROOT COMPONENT
+            if (node.get("metadata").get("component") != null)
+                sbomBuilder.setRootComponent(resolveComponent(componentBuilder, node.get("metadata").get("component")));
+        }
 
         // COMPONENTS
         if (node.get("components") != null)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v7.2.4-alpha] - (8/9/2023)
+
+### Changed
+- `CDX14JSONDeserializer`
+  - `deserialize()` checks for null metadata
+
 ## [v7.2.3-alpha] - (8/7/2023)
 
 ### Added


### PR DESCRIPTION
### Changed
- `CDX14JSONDeserializer`
  - `deserialize()` checks for null metadata

Allowing [scanoss_source_cdx.json](https://drive.google.com/file/d/1IGPqs8_1G6GKiZl1tDB9-OZd7_5ZsZy-/view?usp=drive_link) to pass Serialization test in[ SVIP SBOM Audit](https://docs.google.com/spreadsheets/d/143cSuaTxbVcJq6ENhTUh-DtcrIzPvNuBur89bbQQSSY/edit#gid=1824612488)