### PR TITLE
Hotfix: Rename findByTargetSBOMAndOtherSBOM() to findByTargetSBOMFileAndOtherSBOMFile()

### DIFF
--- a/api/src/main/java/org/svip/api/repository/ComparisonFileRepository.java
+++ b/api/src/main/java/org/svip/api/repository/ComparisonFileRepository.java
@@ -20,5 +20,5 @@ public interface ComparisonFileRepository extends CrudRepository<ComparisonFile,
      *
      * @return ComparisonFile for the target and other sbom
      */
-    ComparisonFile findByTargetSBOMAndOtherSBOM(SBOMFile targetSBOMFile, SBOMFile otherSBOMFile);
+    ComparisonFile findByTargetSBOMFileAndOtherSBOMFile(SBOMFile targetSBOMFile, SBOMFile otherSBOMFile);
 }

--- a/api/src/main/java/org/svip/api/services/DiffService.java
+++ b/api/src/main/java/org/svip/api/services/DiffService.java
@@ -133,7 +133,7 @@ public class DiffService {
                 continue;
 
             // Attempt to get comparison, generate and upload if one doesn't exist.
-            ComparisonFile cf = this.comparisonFileRepository.findByTargetSBOMAndOtherSBOM(targetSBOMFile, otherSBOMFile);
+            ComparisonFile cf = this.comparisonFileRepository.findByTargetSBOMFileAndOtherSBOMFile(targetSBOMFile, otherSBOMFile);
             if(cf == null){
                 Comparison comparison = new Comparison(targetSBOM, otherSBOMFile.toSBOMObject());
                 cf = upload(new UploadComparisonFileInput(comparison).toComparisonFile(targetSBOMFile, otherSBOMFile));


### PR DESCRIPTION
# Overview
A Specific name is required for the "findBy" methods in `ComparisonFileDirectory.java` so that it matches `targetSBOMFile` and `otherSBOMFile` defined in `ComparisonFile.java`. This is preventing the API from being able to run.
