### PR TITLE
Add Relationships header to SPDX23TagValueSerializer

### DIFF
--- a/core/src/main/java/org/svip/serializers/serializer/SPDX23TagValueSerializer.java
+++ b/core/src/main/java/org/svip/serializers/serializer/SPDX23TagValueSerializer.java
@@ -101,10 +101,13 @@ public class SPDX23TagValueSerializer implements Serializer {
         for (SVIPComponentObject pkg : packages)
             out.append(getPackageInfo(pkg));
 
-        out.append("\n### Unpackaged Files\n\n");
+        if (!files.isEmpty())
+            out.append("### Unpackaged Files\n\n");
+
         for (SVIPComponentObject file : files)
             out.append(getFileInfo(file));
 
+        out.append("### Relationships\n\n");
         out.append(getRelationships(sbom.getRelationships()));
 
         return out.toString();


### PR DESCRIPTION
The initial bug was that the merge feature to create a SPDX23 TagValue SBOM was missing the `### Relationships` header. After further investigation, it was found that the SPDX23TagValueSerializer does not append the header.