### PR TITLE
Add OSI heathcheck wait to dockercompose for API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       mysql:
         condition: service_healthy # Only start once the health check has passed
       osi:
-        condition: service_started # Only start once the OSI container has been started
+        condition: service_healthy # Only start once the OSI container has been started
     build: .    # Build from Dockerfile located in root directory
     restart: on-failure
     ports:


### PR DESCRIPTION
Fixes issue when using docker compose when the OSI launches before the API, which the API cannot access the OSI resource